### PR TITLE
Add lib folder to test directory hierarchy

### DIFF
--- a/src/test/resources/project2/TelosysTools/lib/.gitignore
+++ b/src/test/resources/project2/TelosysTools/lib/.gitignore
@@ -1,0 +1,6 @@
+# Purpose of this file is only to allow the addition of lib folder to git repository
+
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Purpose of adding `lib` folder is to fix failure in test execution:
```
org.telosys.tools.commons.TelosysToolsException: Libraries folder : '/home/antoine/workspace/projects/telosys/telosys-tools-repository/src/test/resources/project2/TelosysTools/lib' not found
```